### PR TITLE
Checks document contains parameter bindings before updating CED-43

### DIFF
--- a/src/Piling/CoordinatePilingUpdater .cs
+++ b/src/Piling/CoordinatePilingUpdater .cs
@@ -7,33 +7,21 @@ namespace Jpp.Cedar.Piling
     {
         private UpdaterId _updaterId;
         private PilingCoordinator _pilingCoordinator;      
-
-        private bool registered = false;
-
+        
         private CoordinatePilingUpdater(AddInId id, PilingCoordinator coordinator)
         {
-            if (id == null)
-                throw new ArgumentNullException(nameof(id));
-
-            if (coordinator == null)
-                throw new ArgumentNullException(nameof(coordinator));
-
             _updaterId = new UpdaterId(id, new Guid("a066aabd-7ccd-43c3-9a86-b2089ebabb99"));
-            _pilingCoordinator = coordinator;
+            _pilingCoordinator = coordinator ?? throw new ArgumentNullException(nameof(coordinator));
         }
 
         public void Execute(UpdaterData data)
         {
             if (data == null)
-                throw new System.ArgumentNullException(nameof(data));
+                throw new ArgumentNullException(nameof(data));
 
             Document document = data.GetDocument();
 
-            if (!registered)
-            {
-                registered = true;
-                _pilingCoordinator.RegisterDocument(document);
-            }
+            _pilingCoordinator.RegisterDocument(document);
 
             FilteredElementCollector foundationCollection = new FilteredElementCollector(document).OfCategory(BuiltInCategory.OST_StructuralFoundation);
 

--- a/src/Piling/PilingParameter.cs
+++ b/src/Piling/PilingParameter.cs
@@ -50,10 +50,11 @@ namespace Jpp.Cedar.Piling
         /// <inheritdoc/> 
         public void Bind(Document document)
         {
-            if (_definition == null || !_definition.IsValidObject)
+            if (_definition == null || !_definition.IsValidObject) 
                 Register(document.Application);
 
-            _manager.BindParameter(document, _definition, CATEGORY);
+            if (!document.ParameterBindings.Contains(_definition))
+                _manager.BindParameter(document, _definition, CATEGORY);
         }
 
         public static PilingParameter Easting(ISharedParameterManager manager)

--- a/src/Piling/PilingUpdater.cs
+++ b/src/Piling/PilingUpdater.cs
@@ -8,19 +8,11 @@ namespace Jpp.Cedar.Piling
     {
         private UpdaterId _updaterId;
         private PilingCoordinator _pilingCoordinator;      
-
-        private bool registered = false;
         
         private PilingUpdater(AddInId id, PilingCoordinator coordinator)
         {
-            if (id == null)
-                throw new ArgumentNullException(nameof(id));
-
-            if (coordinator == null)
-                throw new ArgumentNullException(nameof(coordinator));
-
             _updaterId = new UpdaterId(id, new Guid("ddb23f37-892e-4b43-9e8a-0ad8ff381b2b"));
-            _pilingCoordinator = coordinator;
+            _pilingCoordinator = coordinator ?? throw new ArgumentNullException(nameof(coordinator));
         }
 
         public void Execute(UpdaterData data)
@@ -30,11 +22,7 @@ namespace Jpp.Cedar.Piling
 
             Document document = data.GetDocument();
 
-            if (!registered)
-            {
-                registered = true;
-                _pilingCoordinator.RegisterDocument(document);
-            }
+            _pilingCoordinator.RegisterDocument(document);
 
             List<ElementId> modifiedElementIds = new List<ElementId>();
             modifiedElementIds.AddRange(data.GetAddedElementIds());


### PR DESCRIPTION
I've drawn a blank on finding a more efficient way, that handle the rollback of a transaction reliable.